### PR TITLE
Don't require jquery from jquery.ui.core

### DIFF
--- a/vendor/assets/javascripts/jquery.ui.core.js
+++ b/vendor/assets/javascripts/jquery.ui.core.js
@@ -1,5 +1,3 @@
-//= require jquery
-
 /*!
  * jQuery UI 1.8.22
  *
@@ -282,7 +280,7 @@ $.extend( $.ui, {
 			if ( !set || !instance.element[ 0 ].parentNode ) {
 				return;
 			}
-	
+
 			for ( var i = 0; i < set.length; i++ ) {
 				if ( instance.options[ set[ i ][ 0 ] ] ) {
 					set[ i ][ 1 ].apply( instance.element, args );
@@ -290,29 +288,29 @@ $.extend( $.ui, {
 			}
 		}
 	},
-	
+
 	// will be deprecated when we switch to jQuery 1.4 - use jQuery.contains()
 	contains: function( a, b ) {
 		return document.compareDocumentPosition ?
 			a.compareDocumentPosition( b ) & 16 :
 			a !== b && a.contains( b );
 	},
-	
+
 	// only used by resizable
 	hasScroll: function( el, a ) {
-	
+
 		//If overflow is hidden, the element might have extra content, but the user wants to hide it
 		if ( $( el ).css( "overflow" ) === "hidden") {
 			return false;
 		}
-	
+
 		var scroll = ( a && a === "left" ) ? "scrollLeft" : "scrollTop",
 			has = false;
-	
+
 		if ( el[ scroll ] > 0 ) {
 			return true;
 		}
-	
+
 		// TODO: determine which cases actually cause this to happen
 		// if the element doesn't have the scroll set, see if it's possible to
 		// set the scroll
@@ -321,7 +319,7 @@ $.extend( $.ui, {
 		el[ scroll ] = 0;
 		return has;
 	},
-	
+
 	// these are odd functions, fix the API or move into individual plugins
 	isOverAxis: function( x, reference, size ) {
 		//Determines when x coordinate is over "b" element axis


### PR DESCRIPTION
I get why it's there in the first place, but there are a _lot_ of
use cases where you wouldn't want your jquery library included
inline with everything else (preferring to link to a common cdn
version ala google or cdnjs, significant speed increases from
downloading separate files in parallel,etc.). Anyhow, it strikes me
as the sort of thing where you're better off giving people the 
opportunity to choose whether or not to require it themselves rather
than forcing it, hidden away in the depths of the gem. Interested in
your thoughts on this.
