### PR TITLE
Don't force loading jquery through the asset pipeline

### DIFF
--- a/vendor/assets/javascripts/jquery.ui.core.js
+++ b/vendor/assets/javascripts/jquery.ui.core.js
@@ -1,5 +1,3 @@
-//= require jquery
-
 /*!
  * jQuery UI 1.8.23
  *


### PR DESCRIPTION
For our (and probably many) use cases, I want to load jquery from the google/ms/jquery CDN in a production environment.

By requiring jquery in jquery.ui.core, it was forcing all of jquery into the asset pipeline in all cases, even if not necessary.
