### PR TITLE
Don't require jQuery in jquery.ui.core

### DIFF
--- a/vendor/assets/javascripts/jquery.ui.core.js
+++ b/vendor/assets/javascripts/jquery.ui.core.js
@@ -1,5 +1,3 @@
-//= require jquery
-
 /*!
  * jQuery UI 1.8.24
  *


### PR DESCRIPTION
It's important to keep ability to require jquery manually.

For example if you are using CDN (https://github.com/kenn/jquery-rails-cdn) jQuery will be required twice.
