### PR TITLE
Removed jquery requirement from core.js

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -40,10 +40,9 @@ def map_dependencies
 
     deps = build_info['dependencies'].keys
 
-    # jquery.ui.core.js (and only it) should depend on jquery.js itself,
-    # so we remove 'jquery' from the list of dependencies for all files except
-    # jquery.ui.core.js
-    deps.reject! {|d| d == "jquery" } unless source_file_name == 'jquery.ui.core.js'
+    # None of jquery.ui files should depend on jquery.js,
+    # so we remove 'jquery' from the list of dependencies for all files
+    deps.reject! {|d| d == "jquery" }
 
     deps.map! {|d| source_file_for_dependency_entry d }
 
@@ -70,7 +69,7 @@ def get_js_dependencies(basename)
   end
   # Make sure we do not package assets with broken dependencies
   dependencies.each do |dep|
-    unless dep == "jquery.js" || File.exist?("jquery-ui/ui/#{dep}")
+    unless File.exist?("jquery-ui/ui/#{dep}")
       fail "#{basename}: missing #{dep}"
     end
   end

--- a/testapp/Gemfile.lock
+++ b/testapp/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    jquery-ui-rails (2.1.0)
+    jquery-ui-rails (3.0.1)
       jquery-rails
       railties (>= 3.1.0)
 

--- a/vendor/assets/javascripts/jquery.ui.core.js
+++ b/vendor/assets/javascripts/jquery.ui.core.js
@@ -1,5 +1,3 @@
-//= require jquery
-
 /*!
  * jQuery UI Core 1.9.2
  * http://jqueryui.com


### PR DESCRIPTION
I don't think that including jquery in jquery.ui.core is a good idea, because some can get it i.e. from CDN, or require it anyway - it's not mentioned that it's required by UI. 
