### PR TITLE
Create a en-US initialization file for datepicker.

### DIFF
--- a/vendor/assets/javascripts/jquery.ui.datepicker-en-US.js
+++ b/vendor/assets/javascripts/jquery.ui.datepicker-en-US.js
@@ -1,0 +1,23 @@
+/* English/US initialization for the jQuery UI date picker plugin. */
+/* Written by Ashish. */
+jQuery(function($){
+	$.datepicker.regional['en-US'] = {
+		closeText: 'Done',
+		prevText: 'Prev',
+		nextText: 'Next',
+		currentText: 'Today',
+		monthNames: ['January','February','March','April','May','June',
+		'July','August','September','October','November','December'],
+		monthNamesShort: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+		'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+		dayNames: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
+		dayNamesShort: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+		dayNamesMin: ['Su','Mo','Tu','We','Th','Fr','Sa'],
+		weekHeader: 'Wk',
+		dateFormat: 'mm/dd/yy',
+		firstDay: 1,
+		isRTL: false,
+		showMonthAfterYear: false,
+		yearSuffix: ''};
+	$.datepicker.setDefaults($.datepicker.regional['en-US']);
+});


### PR DESCRIPTION
I noticed that if not region is passed, jquery-ui defaults to dd/mm/yy so I thought I should go ahead and add en-US translation. I was not sure how to test this or where to add tests so please let me know how I can rectify that.
