### PR TITLE
add constant for Jquery UI version (fix #41)

### DIFF
--- a/lib/jquery/ui/rails/version.rb
+++ b/lib/jquery/ui/rails/version.rb
@@ -2,6 +2,7 @@ module Jquery
   module Ui
     module Rails
       VERSION = "4.0.3"
+      JQUERY_UI_VERSION = "1.10.3"
     end
   end
 end


### PR DESCRIPTION
This is useful so that you can include the matching version from a CDN, for example.

```
- if Rails.env.production?
  = javascript_include_tag "//ajax.googleapis.com/ajax/libs/jqueryui/#{Jquery::Ui::Rails::JQUERY_UI_VERSION}/jquery-ui.min.js"
- else
  = javascript_include_tag "jquery-ui"
```
