### PR TITLE
Don't force a requirement on jquery-rails, as there are other valid modes of inclusion which eschew it.

### DIFF
--- a/jquery-ui-rails.gemspec
+++ b/jquery-ui-rails.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_dependency "railties", ">= 3.1.0"
-  s.add_dependency "jquery-rails"
 
+  s.add_development_dependency "jquery-rails"
   s.add_development_dependency "json", "~> 1.7"
 
   s.files        = `git ls-files`.split("\n").reject { |f| f =~ /^testapp|^jquery-ui/ }


### PR DESCRIPTION
We use the [conditional comment trick](http://blog.jquery.com/2013/03/01/jquery-2-0-beta-2-released/) to include jquery. As such, we don't rely on `require jquery` via jquery-rails, and in fact using that statement causes our app to break because it would load a second copy of jquery which overwrites the first, which had already been extended with jquery_ujs.

We'd like to remove jquery-rails while still using jquery-ui-rails, but you guys place a hard dependency on it. Doesn't seem necessary to me, could you reconsider?
