### PR TITLE
Editing README.md for Rails 4 users. Application.js and Application...css require jquery.ui.all to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ To require all jQuery UI modules, add the following to your application.js:
 
 ```javascript
 //= require jquery-ui
+
+*** For Rails 4 Users ***
+//= require jquery.ui.all
 ```
 
 Also add the jQuery UI CSS to your application.css:
@@ -43,6 +46,11 @@ Also add the jQuery UI CSS to your application.css:
 /*
  *= require jquery-ui
  */
+
+*** For Rails 4 Users ***
+/*
+//= require jquery.ui.all
+*/
 ```
 
 Warning: If you are using a version below 5.0, you will have to use a different naming


### PR DESCRIPTION
For Rails 4, the new manifest file commands of 'require jquery-ui' do not work. Users must add 'require jquery.ui.all' to both manifest files.
