### PR TITLE
remove link to jquery-ui-sass-rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ interface](http://jqueryui.com/download) again.
 See [VERSIONS.md](VERSIONS.md) to see which versions of jquery-ui-rails bundle
 which versions of jQuery UI.
 
-Also check out the
-[jquery-ui-sass-rails](https://github.com/jhilden/jquery-ui-sass-rails) gem,
-which allows you to override theme variables with Sass.
-
 Warning: This gem is incompatible with the `jquery-rails` gem before version
 3.0.0! Strange things will happen if you use an earlier `jquery-rails`
 version. Run `bundle list` to ensure that you either aren't using


### PR DESCRIPTION
because it is currently not actively maintained. see https://github.com/jhilden/jquery-ui-sass-rails/commit/1bd21de8debfc8ee418c9a4ced79f1bb9b10db9c#commitcomment-12095333