### PR TITLE
Fix “define is not defined” error when jquery-ui file is loaded

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -128,6 +128,9 @@ task :javascripts => :submodule do
         mod.gsub!('/ui', '')
         out.write("//= require #{mod}\n")
       end
+      # core.js is deprecated and uses define function which is usually unavailable
+      # so we need only dependency loading there with no file contents
+      next if clean_path == 'jquery-ui/core.js'
       out.write("\n") unless dep_modules.empty?
       source_code = File.read(path)
       source_code.gsub!('@VERSION', version)

--- a/app/assets/javascripts/jquery-ui/core.js
+++ b/app/assets/javascripts/jquery-ui/core.js
@@ -13,25 +13,3 @@
 //= require jquery-ui/tabbable
 //= require jquery-ui/unique-id
 //= require jquery-ui/version
-
-// This file is deprecated in 1.12.0 to be removed in 1.13
-( function() {
-define( [
-	"jquery",
-	"./data",
-	"./disable-selection",
-	"./focusable",
-	"./form",
-	"./ie",
-	"./keycode",
-	"./labels",
-	"./jquery-1-7",
-	"./plugin",
-	"./safe-active-element",
-	"./safe-blur",
-	"./scroll-parent",
-	"./tabbable",
-	"./unique-id",
-	"./version"
-] );
-} )();


### PR DESCRIPTION
This PR simply ignores contents of `core.js` file since this is an index and we explicitly load all required files with Rails Assets pipeline. Fixes #108 #112 (more info in #108)