### PR TITLE
Replace deprecated/removed `File.exists?` alias

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -203,7 +203,7 @@ task :stylesheets => :submodule do
         dependencies.each do |dependency|
           dependency = dependency.sub(/\.js$/, '')
           dependent_stylesheet = "#{dependency}.css"
-          extra_dependencies << dependency if File.exists?("#{css_dir}/#{dependent_stylesheet}")
+          extra_dependencies << dependency if File.exist?("#{css_dir}/#{dependent_stylesheet}")
         end
         extra_dependencies << 'theme'
       end

--- a/testapp/config/boot.rb
+++ b/testapp/config/boot.rb
@@ -3,4 +3,4 @@ require 'rubygems'
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
-require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])


### PR DESCRIPTION
The alias `File.exists?` was removed in Ruby 3.2:

* https://bugs.ruby-lang.org/issues/17391
* https://rubyreferences.github.io/rubychanges/3.2.html#removals

`File.exist?` has been in Ruby since at least 1.8: https://ruby-doc.org/core-1.8.6/File.html#method-c-exist-3F